### PR TITLE
Added sequence diagram for github booster to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,13 @@ sequenceDiagram
     participant Alice as Alice (Developer)
 
     Bob->>Extension: Initiates a boost request
-    Extension->>NostrizeRelay: Sends zap request to Nostrize<br />with metadata indicating that the payment is for Alice
-    NostrizeRelay->>NostrizeNode: Forwards zap request
-    NostrizeNode-->>Extension: Generates Lightning Invoice
+    Extension->>NostrizeNode: Sends a zap request to Nostrize<br />with tag ["p", "<pubkey_of_alice>"]
+    NostrizeNode-->>Extension: Generates and sends the Lightning Invoice
     Extension-->>Bob: Displays Lightning Invoice
     Bob->>NostrizeNode: Pays the invoice (10000 sats)
     NostrizeNode->>Alice: Sends 9600 sats to Alice's wallet
     NostrizeNode-->>NostrizeRelay: Confirms payment, creates zap receipt
-    NostrizeRelay-->>Extension: Sends boost event receipt
+    NostrizeRelay-->>Extension: Gets zap receipt from node,<br />sends it to the extension and creates a boost event
     Extension-->>Bob: Displays confirmation of boost
     NostrizeRelay->>NostrizeRelay: Stores boost request and receipt
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,42 @@ With Nostrize on GitHub, you can:
   * Earn payments for your pull requests that address and resolve issues.
 * And more features are coming...
 
+### Nostrize Booster
+
+Nostrize Booster is designed for GitHub and may be added for other platforms later.
+
+Nostrize users can make a boost to a github user, organization or a repository for endorsement, to a PR for visibility that more people can see and review it, or to a github issue for again for visibility hoping people would see and share a workaround or fix it. 
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Bob as Bob (User)
+    participant Extension as Nostrize Extension
+    participant NostrizeRelay as Nostrize Relay
+    participant NostrizeNode as Nostrize Lightning Node
+    participant Alice as Alice (Developer)
+
+    Bob->>Extension: Initiates a boost request
+    Extension->>NostrizeRelay: Sends zap request to Nostrize<br />with metadata indicating that the payment is for Alice
+    NostrizeRelay->>NostrizeNode: Forwards zap request
+    NostrizeNode-->>Extension: Generates Lightning Invoice
+    Extension-->>Bob: Displays Lightning Invoice
+    Bob->>NostrizeNode: Pays the invoice (10000 sats)
+    NostrizeNode->>Alice: Sends 9600 sats to Alice's wallet
+    NostrizeNode-->>NostrizeRelay: Confirms payment, creates zap receipt
+    NostrizeRelay-->>Extension: Sends boost event receipt
+    Extension-->>Bob: Displays confirmation of boost
+    NostrizeRelay->>NostrizeRelay: Stores boost request and receipt
+
+    autonumber 1
+
+    alt Boost Visibility
+        Other Users->>NostrizeRelay: Fetch boost events
+        NostrizeRelay-->>Other Users: Return boost events
+        Extension-->>Other Users: Displays boosts on GitHub homepage
+    end
+```
+
 ## Telegram Web (web.telegram.org)
 
 The latest integration of Nostrize. Add your npub to your bio and you're ready to go!

--- a/src/twitter/profile/profile.js
+++ b/src/twitter/profile/profile.js
@@ -19,7 +19,9 @@ async function twitterProfilePage() {
 
   const log = logger({ ...settings.debug, namespace: "[N][X-Profile]" });
 
-  const accountName = window.location.href.match(/^https:\/\/x\.com\/(.*)$/)[1];
+  const accountName = window.location.href.match(
+    /^https:\/\/x\.com\/(.*?)(?=\?|\s|$)/,
+  )[1];
 
   log("accountName", accountName);
 


### PR DESCRIPTION
Starting with the Nostrize Booster feature for Github.
Added sequence diagram.

Will need a special relay for storing zap/boost events, possible in a different repo

In the Extension, we can write the code as if this relay exists.

There may be a need for a new setting such as, publish zap/boost events only to nostrize relay. otherwise all the relays would get the zap events but I don't think it is necessary

I need a lightning node too, but it is related to the relay code, not here

After getting the boost events from the relay, should transform it into Boost format:

```
    {
      type: "repo",
      from: "nostrize",
      to: "nbd-wtf/nostr-tools",
      created_at: agoInSeconds({ hours: 34 }),
      amountSats: 21000,
      message:
        "One of the coolest nostr software out there 😎 a must have for every client developer",
    }
```